### PR TITLE
🐛 fix: touch command should expect response TOUCHED or NOT_FOUND

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -374,7 +374,7 @@ pub fn touch<'a>(job_id: u64) -> Command<'a> {
         CommandKind::Touch,
         vec![job_id.to_string()],
         None,
-        vec![Status::Ok],
+        vec![Status::Touched],
         vec![Status::NotFound],
     )
 }


### PR DESCRIPTION
fix issue metioned [here](https://github.com/iFaceless/beanstalkc-rust/issues/2).