### PR TITLE
Allow Job body to be "anything" (Vec<u8> instead of String)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 .idea/
-
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ path = "src/lib.rs"
 bufstream = "0.1.4"
 serde = "^1.0"
 serde_yaml = "^0.8"
+
+[dev-dependencies]
+flate2 = "1.0.17"

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut job = conn.reserve()?;
     dbg!(job.id());
-    dbg!(job.body_utf8())?;
+    dbg!(std::str::from_utf8(job.body()))?;
     dbg!(job.reserved());
     dbg!(job.bury_default())?;
     dbg!(job.kick())?;

--- a/src/beanstalkc.rs
+++ b/src/beanstalkc.rs
@@ -213,7 +213,7 @@ impl Beanstalkc {
         Ok(Job::new(
             self,
             resp.job_id()?,
-            resp.body.unwrap_or_default(),
+            Vec::from(resp.body.unwrap_or_default()),
             true,
         ))
     }
@@ -241,7 +241,7 @@ impl Beanstalkc {
         Ok(Job::new(
             self,
             resp.job_id()?,
-            resp.body.unwrap_or_default(),
+            Vec::from(resp.body.unwrap_or_default()),
             true,
         ))
     }
@@ -349,7 +349,7 @@ impl Beanstalkc {
         Ok(Job::new(
             self,
             resp.job_id()?,
-            resp.body.unwrap_or_default(),
+            Vec::from(resp.body.unwrap_or_default()),
             false,
         ))
     }
@@ -367,7 +367,7 @@ impl Beanstalkc {
     /// assert!(tubes.contains(&String::from("default")));
     /// ```
     pub fn tubes(&mut self) -> BeanstalkcResult<Vec<String>> {
-        self.send(command::tubes()).map(|r| r.body_as_vec())
+        Ok(self.send(command::tubes())?.body_as_vec()?)
     }
 
     /// Return the tube currently being used.
@@ -416,7 +416,7 @@ impl Beanstalkc {
     /// assert_eq!(vec!["default".to_string()], tubes);
     /// ```
     pub fn watching(&mut self) -> BeanstalkcResult<Vec<String>> {
-        self.send(command::watching()).map(|r| r.body_as_vec())
+        Ok(self.send(command::watching())?.body_as_vec()?)
     }
 
     /// Watch a specific tube.
@@ -463,7 +463,7 @@ impl Beanstalkc {
     /// dbg!(conn.stats().unwrap());
     /// ```
     pub fn stats(&mut self) -> BeanstalkcResult<HashMap<String, String>> {
-        self.send(command::stats()).map(|r| r.body_as_map())
+        Ok(self.send(command::stats())?.body_as_map()?)
     }
 
     /// Return a dict of statistical information about the specified tube.
@@ -478,8 +478,7 @@ impl Beanstalkc {
     /// dbg!(conn.stats_tube("default").unwrap());
     /// ```
     pub fn stats_tube(&mut self, name: &str) -> BeanstalkcResult<HashMap<String, String>> {
-        self.send(command::stats_tube(name))
-            .map(|r| r.body_as_map())
+        Ok(self.send(command::stats_tube(name))?.body_as_map()?)
     }
 
     /// Pause the specific tube for `delay` time.
@@ -607,8 +606,7 @@ impl Beanstalkc {
     /// dbg!(stats);
     /// ```
     pub fn stats_job(&mut self, job_id: u64) -> BeanstalkcResult<HashMap<String, String>> {
-        self.send(command::stats_job(job_id))
-            .map(|r| r.body_as_map())
+        Ok(self.send(command::stats_job(job_id))?.body_as_map()?)
     }
 
     fn send(&mut self, cmd: command::Command) -> BeanstalkcResult<Response> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::net::AddrParseError;
 use std::num::ParseIntError;
 use std::string::FromUtf8Error;
+use std::str::Utf8Error;
 
 #[derive(Debug, Clone)]
 pub enum BeanstalkcError {
@@ -46,6 +47,12 @@ impl From<ParseIntError> for BeanstalkcError {
 
 impl From<FromUtf8Error> for BeanstalkcError {
     fn from(err: FromUtf8Error) -> Self {
+        BeanstalkcError::UnexpectedResponse(err.to_string())
+    }
+}
+
+impl From<Utf8Error> for BeanstalkcError {
+    fn from(err: Utf8Error) -> Self {
         BeanstalkcError::UnexpectedResponse(err.to_string())
     }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;
-use std::str;
 
 use crate::config::DEFAULT_JOB_DELAY;
 use crate::config::DEFAULT_JOB_PRIORITY;
@@ -46,12 +45,6 @@ impl<'a> Job<'a> {
     /// Return job body.
     pub fn body(&self) -> &[u8] {
         &self.body[..]
-    }
-
-    /// Return job body as UTF-8 `&str`  
-    /// This method is just calling `std::str::from_utf8(&self.body)`
-    pub fn body_utf8(&self) -> BeanstalkcResult<&str> {
-        Ok(str::from_utf8(&self.body)?)
     }
 
     /// Return job reserving status.

--- a/src/job.rs
+++ b/src/job.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;
+use std::str;
 
 use crate::config::DEFAULT_JOB_DELAY;
 use crate::config::DEFAULT_JOB_PRIORITY;
@@ -12,7 +13,7 @@ use crate::Beanstalkc;
 pub struct Job<'a> {
     conn: &'a mut Beanstalkc,
     id: u64,
-    body: String,
+    body: Vec<u8>,
     reserved: bool,
 }
 
@@ -20,7 +21,7 @@ impl<'a> fmt::Display for Job<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(
             f,
-            "Job(id: {}, reserved: {}, body: \"{}\")",
+            "Job(id: {}, reserved: {}, body: \"{:?}\")",
             self.id, self.reserved, self.body
         )
     }
@@ -28,7 +29,7 @@ impl<'a> fmt::Display for Job<'a> {
 
 impl<'a> Job<'a> {
     /// Initialize and return the `Job` object.
-    pub fn new(conn: &'a mut Beanstalkc, job_id: u64, body: String, reserved: bool) -> Job {
+    pub fn new(conn: &'a mut Beanstalkc, job_id: u64, body: Vec<u8>, reserved: bool) -> Job {
         Job {
             conn,
             id: job_id,
@@ -43,8 +44,14 @@ impl<'a> Job<'a> {
     }
 
     /// Return job body.
-    pub fn body(&self) -> &str {
-        self.body.as_str()
+    pub fn body(&self) -> &[u8] {
+        &self.body[..]
+    }
+
+    /// Return job body as UTF-8 `&str`  
+    /// This method is just calling `std::str::from_utf8(&self.body)`
+    pub fn body_utf8(&self) -> BeanstalkcResult<&str> {
+        Ok(str::from_utf8(&self.body)?)
     }
 
     /// Return job reserving status.

--- a/src/request.rs
+++ b/src/request.rs
@@ -50,7 +50,7 @@ impl<'b> Request<'b> {
         let body = &mut tmp[..];
         self.stream.read_exact(body)?;
         tmp.truncate(body_byte_count);
-        response.body = Some(String::from_utf8(tmp)?);
+        response.body = Some(tmp);
 
         Ok(response)
     }


### PR DESCRIPTION
First of all, thanks for the amazing work on this Beanstalkd client.

I was about to use it for a project but I needed Jobs to be able to handle raw bytes payloads (not just utf-8 encoded strings).
Long story short, we send gzipped payload (that might not be all utf-8 chars), which lead to Utf8Error [in the automatic conversion](https://github.com/iFaceless/beanstalkc-rust/blob/master/src/request.rs#L53).
We can argue this choice, but we could also give the choice to the library users, with this pull request :)

So, this is a slight modification of the API:
```rust
pub struct Job<'a> {
    // ...
    body: Vec<u8>, // instead of String
    // ...
}

// and the impacted bits here and there, mainly:

impl<'a> Job<'a> {
    // ...
    /// Return job body.
    pub fn body(&self) -> &[u8] {
        &self.body[..]
    }

    /// Return job body as UTF-8 `&str`  
    /// This method is just calling `std::str::from_utf8(&self.body)`
    pub fn body_utf8(&self) -> BeanstalkcResult<&str> {
        Ok(str::from_utf8(&self.body)?)
    }
   // ...

  // and some other stuff
```
I'm pretty sure you don't want to merge this as-is, so feel free to ask for modifications.﻿
