### PR TITLE
fix unsound conversion from [u8] to String

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -163,11 +163,11 @@ impl<'a> Command<'a> {
             cmd = cmd + SPACE + self.args.clone().join(SPACE).as_str();
         }
 
-        if self.body.is_some() {
-            cmd = cmd + SPACE + self.body.unwrap().len().to_string().as_str() + LINE_BREAK;
+        if let Some(body) = self.body {
+            cmd = cmd + SPACE + body.len().to_string().as_str() + LINE_BREAK;
 
-            let utf8body = unsafe { String::from_utf8_unchecked(self.body.unwrap().to_vec()) };
-            cmd.push_str(utf8body.as_str());
+            let utf8body = String::from_utf8_lossy(body);
+            cmd.push_str(&utf8body);
         }
         cmd.push_str(LINE_BREAK);
 


### PR DESCRIPTION
There's currently an unsound conversion accessible with public functions.
```
     pub fn Beanstalkc::put(body: &[u8], ...) -> BeanstalkcResult<u64> {
         self.send(command::put(body, ...))
             ...
     }
     fn Command::put(body: &[u8], ...) -> Command {
         Command::new(Some(body), ...)
     }
     fn Command::new(body: Option<&[u8]>, ...) -> String {
         Command {body, ...}
     }
     fn Beanstalkc::send(cmd: command::Command, ...) -> BeanstalkcResult<Response> {
         ...
         let resp = request.send(cmd.build().as_bytes())?;
         ...
     }
     fn Command::build(&self) -> String {
         ...
             if self.body.is_some() {
                 ...
                 let utf8body = unsafe { String::from_utf8_unchecked(self.body.unwrap().to_vec()) };
                 ...
             }
         ...
     }

```
This is the minimal change needed to fix the problem. Alternatives are to simply use `[u8]` throughout the codebase or perform the conversion as early as possible. `unsafe` blocks should usually be accompanied by comments indicating why they are needed and sound.